### PR TITLE
Emit query log in quaint:query span, rather than in its parent

### DIFF
--- a/src/connector/metrics.rs
+++ b/src/connector/metrics.rs
@@ -14,8 +14,16 @@ where
     U: Future<Output = crate::Result<T>>,
 {
     let span = info_span!("quaint:query", "db.statement" = %query);
+    do_query(tag, query, params, f).instrument(span).await
+}
+
+async fn do_query<'a, F, T, U>(tag: &'static str, query: &'a str, params: &'a [Value<'_>], f: F) -> crate::Result<T>
+where
+    F: FnOnce() -> U + 'a,
+    U: Future<Output = crate::Result<T>>,
+{
     let start = Instant::now();
-    let res = f().instrument(span).await;
+    let res = f().await;
 
     let result = match res {
         Ok(_) => "success",


### PR DESCRIPTION
Addressed the problem expressed in https://github.com/prisma/client-planning/issues/158#issuecomment-1405530608

Before this change query log events where not attached to the `quaint:query` span but its parent. This had implications on log capturing. mainly, that `BEGIN` iTX queries where not logged until its owner span (itx_runner) was not closed at the end of the transaction. 